### PR TITLE
Add Discord Rules page to intro section

### DIFF
--- a/docs/intro/rules.md
+++ b/docs/intro/rules.md
@@ -1,0 +1,21 @@
+---
+title: "Discord Rules"
+---
+
+# {{ $frontmatter.title }}
+
+1. Follow the Discord [Terms of Service](https://discordapp.com/terms) and [Community Guidelines](https://discordapp.com/guidelines). Serious violations will result in a ban and a report.
+
+2. No excessive profanity, racial slurs, or rude behaviour. This server must be suitable for all ages.
+
+3. No jetpacks.
+
+4. Do not discuss controversial topics that could potentially lead to argument, e.g. opinions related to religion or politics
+
+5. Do not distribute, present or discuss cheats, hacks or exploits with malicious intent
+
+6. Be kind with the community, include new members, and participate in community events!
+
+7. No inappropriate names or nicknames.
+
+8. Have fun - this is our primary goal!


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52345992/222203244-d62397e1-34fd-4b31-89f4-c8c3655ca816.png)

As per this discussion in October, here are the current Discord rules copied straight from the "rules screening" section of the Discord. This is to let members see the rules after accepting them. 